### PR TITLE
Documentation: Fix name of `jqwik-kotlin`

### DIFF
--- a/documentation/src/docs/include/kotlin-module.md
+++ b/documentation/src/docs/include/kotlin-module.md
@@ -1,4 +1,4 @@
-This module's artefact name is `jqwik-Module`. 
+This module's artefact name is `jqwik-kotlin`. 
 It's supposed to simplify and streamline using _jqwik_ in Kotlin projects. 
 
 This module is _not_ in jqwik's default dependencies. 


### PR DESCRIPTION
The documentation on https://jqwik.net/docs/current/user-guide.html#kotlin-module reads:
> This module’s artefact name is jqwik-Module.

where it should be

> This module’s artefact name is jqwik-kotlin. 

This PR fixes this.

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
